### PR TITLE
Enable interactive viewer and locator editing

### DIFF
--- a/AMmain.py
+++ b/AMmain.py
@@ -9,14 +9,247 @@ from PySide2 import QtWidgets, QtCore, QtGui, QtUiTools
 
 import AMUtilities
 import AMCameraCalibrate
+import numpy as np
+import cv2
 
 # Держим ссылку глобально, чтобы окно не закрывалось сразу
 main_window = None
 
+
+class ImageViewer(QtWidgets.QGraphicsView):
+    """Interactive viewer placed inside ``MainFrame`` with modern controls."""
+
+    locator_added = QtCore.Signal(float, float)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setScene(QtWidgets.QGraphicsScene(self))
+        self._pixmap = QtWidgets.QGraphicsPixmapItem()
+        self.scene().addItem(self._pixmap)
+        self.mark_items = []
+
+        self.setRenderHints(QtGui.QPainter.Antialiasing | QtGui.QPainter.SmoothPixmapTransform)
+        self.setTransformationAnchor(QtWidgets.QGraphicsView.NoAnchor)
+        self.setResizeAnchor(QtWidgets.QGraphicsView.NoAnchor)
+        self.setDragMode(QtWidgets.QGraphicsView.NoDrag)
+
+        self._panning = False
+        self._pan_start = QtCore.QPoint()
+        self.adding_locator = False
+
+    def load_image(self, qimg: QtGui.QImage):
+        self.scene().setSceneRect(0, 0, qimg.width(), qimg.height())
+        self._pixmap.setPixmap(QtGui.QPixmap.fromImage(qimg))
+        self.fitInView(self.sceneRect(), QtCore.Qt.KeepAspectRatio)
+
+    def set_markers(self, markers, highlight_name=None):
+        for item in self.mark_items:
+            self.scene().removeItem(item)
+        self.mark_items = []
+        for m in markers:
+            self._add_marker_item(
+                m["x"], m["y"], m.get("name", ""), m.get("name") == highlight_name
+            )
+
+    def _add_marker_item(self, x_norm: float, y_norm: float, name: str, highlight: bool = False):
+        rect = QtCore.QRectF(-5, -5, 10, 10)
+        item = QtWidgets.QGraphicsEllipseItem(rect)
+        color = QtCore.Qt.green if highlight else QtCore.Qt.red
+        item.setBrush(QtGui.QBrush(color))
+        item.setPen(QtGui.QPen(QtCore.Qt.black))
+        pos = QtCore.QPointF(x_norm * self.sceneRect().width(), y_norm * self.sceneRect().height())
+        item.setPos(pos)
+        item.setFlag(QtWidgets.QGraphicsItem.ItemIgnoresTransformations)
+        self.scene().addItem(item)
+        text = QtWidgets.QGraphicsSimpleTextItem(name)
+        text.setFlag(QtWidgets.QGraphicsItem.ItemIgnoresTransformations)
+        text.setPos(pos + QtCore.QPointF(6, -6))
+        self.scene().addItem(text)
+        self.mark_items.append(item)
+        self.mark_items.append(text)
+
+    def mousePressEvent(self, event):
+        if self.adding_locator and event.button() == QtCore.Qt.LeftButton:
+            pos = self.mapToScene(event.pos())
+            x_norm = pos.x() / self.sceneRect().width()
+            y_norm = pos.y() / self.sceneRect().height()
+            self.locator_added.emit(x_norm, y_norm)
+            return
+
+        if event.button() == QtCore.Qt.MiddleButton:
+            self._panning = True
+            self._pan_start = event.pos()
+            self.setCursor(QtCore.Qt.ClosedHandCursor)
+            event.accept()
+            return
+        if event.button() == QtCore.Qt.RightButton:
+            self._show_context_menu(event)
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if self._panning:
+            delta = event.pos() - self._pan_start
+            self._pan_start = event.pos()
+            self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - delta.x())
+            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - delta.y())
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == QtCore.Qt.MiddleButton and self._panning:
+            self._panning = False
+            self.setCursor(QtCore.Qt.ArrowCursor)
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+    def wheelEvent(self, event):
+        if event.modifiers() & QtCore.Qt.ControlModifier:
+            if event.angleDelta().y() > 0:
+                next_image()
+            else:
+                prev_image()
+            event.accept()
+            return
+        factor = 1.2 if event.angleDelta().y() > 0 else 1 / 1.2
+        self.setTransformationAnchor(QtWidgets.QGraphicsView.AnchorUnderMouse)
+        self.scale(factor, factor)
+        self.setTransformationAnchor(QtWidgets.QGraphicsView.NoAnchor)
+        event.accept()
+
+    def _show_context_menu(self, event):
+        menu = QtWidgets.QMenu(self)
+        menu.addAction("Add Locator", add_locator)
+        menu.addAction("Calibrate", calibrate)
+        menu.addAction("Load Images", import_images)
+        menu.addAction("Save Scene", save_scene)
+        menu.exec_(self.mapToGlobal(event.pos()))
+
+    def mouseDoubleClickEvent(self, event):
+        if self._pixmap.pixmap() and not self._pixmap.pixmap().isNull():
+            self.fitInView(self.sceneRect(), QtCore.Qt.KeepAspectRatio)
+        super().mouseDoubleClickEvent(event)
+
+
+def get_image_markers(index: int):
+    """Return list of markers for the given image index."""
+    markers = []
+    for loc in getattr(main_window, "locators", []):
+        pos = loc.get("positions", {}).get(index)
+        if pos:
+            markers.append({"name": loc["name"], "x": pos["x"], "y": pos["y"]})
+    return markers
+
+
+def update_tree():
+    """Rebuild the tree with image and locator nodes."""
+    tree = main_window.MainTree
+    tree.clear()
+
+    img_root = QtWidgets.QTreeWidgetItem(tree, ["Images"])
+    img_root.setData(0, QtCore.Qt.UserRole, ("images_root",))
+    for idx, path in enumerate(main_window.image_paths):
+        item = QtWidgets.QTreeWidgetItem(img_root, [Path(path).name])
+        item.setData(0, QtCore.Qt.UserRole, ("image", idx))
+
+    loc_root = QtWidgets.QTreeWidgetItem(tree, ["Locators"])
+    loc_root.setData(0, QtCore.Qt.UserRole, ("loc_root",))
+    for loc in getattr(main_window, "locators", []):
+        item = QtWidgets.QTreeWidgetItem(loc_root, [loc["name"]])
+        item.setData(0, QtCore.Qt.UserRole, ("locator", loc["name"]))
+
+    img_root.setExpanded(True)
+    loc_root.setExpanded(True)
+
+
+def exit_locator_mode():
+    """Reset locator placement mode."""
+    main_window.locator_mode = False
+    main_window.current_locator = None
+    main_window.viewer.adding_locator = False
+    main_window.viewer.setCursor(QtCore.Qt.ArrowCursor)
+
+
+def show_image(index: int):
+    if 0 <= index < len(main_window.images):
+        main_window.current_image_index = index
+        main_window.viewer.load_image(main_window.images[index])
+        highlight = getattr(main_window, "selected_locator", None)
+        main_window.viewer.set_markers(get_image_markers(index), highlight)
+
+
+def next_image():
+    idx = getattr(main_window, "current_image_index", 0) + 1
+    if idx < len(main_window.images):
+        show_image(idx)
+        root = main_window.MainTree.topLevelItem(0)
+        if root and idx < root.childCount():
+            main_window.MainTree.setCurrentItem(root.child(idx))
+
+
+def prev_image():
+    idx = getattr(main_window, "current_image_index", 0) - 1
+    if idx >= 0:
+        show_image(idx)
+        root = main_window.MainTree.topLevelItem(0)
+        if root and idx < root.childCount():
+            main_window.MainTree.setCurrentItem(root.child(idx))
+
+
+def on_tree_selection_changed(current, _previous):
+    if not current:
+        return
+    data = current.data(0, QtCore.Qt.UserRole)
+    if not data:
+        return
+    if data[0] == "image":
+        main_window.selected_locator = None
+        show_image(data[1])
+    elif data[0] == "locator":
+        main_window.selected_locator = data[1]
+        show_image(getattr(main_window, "current_image_index", 0))
+
+
+def delete_selected_locator():
+    item = main_window.MainTree.currentItem()
+    if not item:
+        return
+    data = item.data(0, QtCore.Qt.UserRole)
+    if not data or data[0] != "locator":
+        return
+    name = data[1]
+    main_window.locators = [l for l in main_window.locators if l["name"] != name]
+    if main_window.selected_locator == name:
+        main_window.selected_locator = None
+    update_tree()
+    show_image(getattr(main_window, "current_image_index", 0))
+
+
+def on_locator_added(x_norm: float, y_norm: float):
+    idx = getattr(main_window, "current_image_index", 0)
+    if idx >= len(main_window.image_paths):
+        return
+    loc = getattr(main_window, "current_locator", None)
+    if not loc:
+        return
+    loc.setdefault("positions", {})[idx] = {"x": x_norm, "y": y_norm}
+    update_tree()
+    show_image(idx)
+
+
+
 def new_scene():
     main_window.image_paths = []
     main_window.images = []
-    main_window.MainTree.clear()
+    main_window.locators = []
+    main_window.current_locator = None
+    main_window.selected_locator = None
+    main_window.locator_counter = 1
+    update_tree()
+    main_window.viewer._pixmap.setPixmap(QtGui.QPixmap())
+    main_window.viewer.set_markers([])
     QtWidgets.QMessageBox.information(main_window, "New", "Started a new scene.")
 
 def import_images():
@@ -26,9 +259,16 @@ def import_images():
     paths = AMUtilities.verify_paths(paths)
     main_window.image_paths = paths
     main_window.images = AMUtilities.load_images(paths)
-    main_window.MainTree.clear()
-    for p in main_window.image_paths:
-        QtWidgets.QTreeWidgetItem(main_window.MainTree, [Path(p).name])
+    main_window.locators = []
+    main_window.current_locator = None
+    main_window.selected_locator = None
+    main_window.locator_counter = 1
+    update_tree()
+    if main_window.images:
+        show_image(0)
+    else:
+        main_window.viewer._pixmap.setPixmap(QtGui.QPixmap())
+        main_window.viewer.set_markers([])
 
 def save_scene():
     path, _ = QtWidgets.QFileDialog.getSaveFileName(
@@ -36,7 +276,10 @@ def save_scene():
     )
     if not path:
         return
-    scene = {"images": getattr(main_window, "image_paths", [])}
+    scene = {
+        "images": getattr(main_window, "image_paths", []),
+        "locators": getattr(main_window, "locators", []),
+    }
     AMUtilities.save_scene(scene, path)
 
 def save_scene_as():
@@ -51,9 +294,23 @@ def load_scene():
     scene = AMUtilities.load_scene(path)
     main_window.image_paths = scene.get("images", [])
     main_window.images = AMUtilities.load_images(main_window.image_paths)
-    main_window.MainTree.clear()
-    for p in main_window.image_paths:
-        QtWidgets.QTreeWidgetItem(main_window.MainTree, [Path(p).name])
+    main_window.locators = scene.get("locators", [])
+    main_window.current_locator = None
+    main_window.selected_locator = None
+    main_window.locator_counter = 1
+    for loc in main_window.locators:
+        try:
+            num = int(loc["name"].lstrip("loc"))
+            if num >= main_window.locator_counter:
+                main_window.locator_counter = num + 1
+        except Exception:
+            pass
+    update_tree()
+    if main_window.images:
+        show_image(0)
+    else:
+        main_window.viewer._pixmap.setPixmap(QtGui.QPixmap())
+        main_window.viewer.set_markers([])
 
 def open_recent_project():
     QtWidgets.QMessageBox.information(main_window, "Recent", "Recent projects not implemented.")
@@ -68,10 +325,58 @@ def redo():
     QtWidgets.QMessageBox.information(main_window, "Redo", "Redo not implemented.")
 
 def add_locator():
-    QtWidgets.QMessageBox.information(main_window, "Add Locator", "Create/Move marker not implemented.")
+    if not main_window.images:
+        QtWidgets.QMessageBox.warning(main_window, "Add Locator", "No image loaded.")
+        return
+    if getattr(main_window, "locator_mode", False):
+        exit_locator_mode()
+    name = f"loc{main_window.locator_counter}"
+    main_window.locator_counter += 1
+    main_window.current_locator = {"name": name, "positions": {}}
+    main_window.locators.append(main_window.current_locator)
+    main_window.viewer.adding_locator = True
+    main_window.viewer.setCursor(QtCore.Qt.CrossCursor)
+    main_window.locator_mode = True
+    QtWidgets.QMessageBox.information(
+        main_window,
+        "Add Locator",
+        f"Placing {name}. Click on images to mark its position. Press Esc to finish.",
+    )
 
 def calibrate():
-    QtWidgets.QMessageBox.information(main_window, "Calibrate", "Calibration routine not implemented.")
+    if not getattr(main_window, "image_paths", []):
+        QtWidgets.QMessageBox.warning(main_window, "Calibrate", "No images loaded for calibration.")
+        return
+
+    board_size = (9, 6)
+    objp = np.zeros((board_size[0] * board_size[1], 3), np.float32)
+    objp[:, :2] = np.mgrid[0:board_size[0], 0:board_size[1]].T.reshape(-1, 2)
+
+    image_points = []
+    object_points = []
+    image_size = None
+
+    for img_path in main_window.image_paths:
+        img = cv2.imread(img_path, cv2.IMREAD_GRAYSCALE)
+        if img is None:
+            continue
+        if image_size is None:
+            image_size = (img.shape[1], img.shape[0])
+        ret, corners = cv2.findChessboardCorners(img, board_size, None)
+        if ret:
+            object_points.append(objp)
+            image_points.append(corners)
+
+    if not image_points:
+        QtWidgets.QMessageBox.warning(main_window, "Calibrate", "Chessboard corners not found in any image.")
+        return
+
+    result = AMCameraCalibrate.calibrate_cameras(image_points, object_points, image_size)
+    QtWidgets.QMessageBox.information(
+        main_window,
+        "Calibration Completed",
+        f"Reprojection error: {result.reprojection_error:.4f}",
+    )
 
 def define_worldspace():
     QtWidgets.QMessageBox.information(main_window, "Worldspace", "Define worldspace not implemented.")
@@ -99,6 +404,49 @@ try:
         # Инициализация служебных полей для сцены и изображений
         main_window.image_paths = []
         main_window.images = []
+        main_window.locators = []
+        main_window.current_locator = None
+        main_window.selected_locator = None
+        main_window.locator_mode = False
+        main_window.locator_counter = 1
+
+        # Viewer setup inside MainFrame
+        layout = QtWidgets.QVBoxLayout(main_window.MainFrame)
+        layout.setContentsMargins(0, 0, 0, 0)
+        main_window.viewer = ImageViewer(main_window.MainFrame)
+        main_window.viewer.locator_added.connect(on_locator_added)
+        layout.addWidget(main_window.viewer)
+
+        # Tree selection and delete key
+        main_window.MainTree.currentItemChanged.connect(on_tree_selection_changed)
+
+        class _DeleteFilter(QtCore.QObject):
+            def eventFilter(self, obj, event):
+                if event.type() == QtCore.QEvent.KeyPress and event.key() == QtCore.Qt.Key_Delete:
+                    delete_selected_locator()
+                    return True
+                return super().eventFilter(obj, event)
+
+        main_window._del_filter = _DeleteFilter(main_window.MainTree)
+        main_window.MainTree.installEventFilter(main_window._del_filter)
+
+        class _KeyFilter(QtCore.QObject):
+            def eventFilter(self, obj, event):
+                if event.type() == QtCore.QEvent.KeyPress:
+                    if event.key() == QtCore.Qt.Key_Escape:
+                        exit_locator_mode()
+                        return True
+                    if event.key() == QtCore.Qt.Key_Right:
+                        next_image()
+                        return True
+                    if event.key() == QtCore.Qt.Key_Left:
+                        prev_image()
+                        return True
+                return super().eventFilter(obj, event)
+
+        main_window._key_filter = _KeyFilter(main_window.viewer)
+        main_window.viewer.installEventFilter(main_window._key_filter)
+        main_window.MainTree.installEventFilter(main_window._key_filter)
 
         # Toolbar buttons
         main_window.btnAddLoc.clicked.connect(add_locator)


### PR DESCRIPTION
## Summary
- embed custom `ImageViewer` into `MainFrame`
- rebuild scene tree with locator data
- add locator management and delete-key support
- wire viewer events and tree selection to update overlays
- allow placement across images with ESC to cancel
- support smooth zoom, middle-button panning, Ctrl+wheel image switching, context menu, and arrow-key navigation

## Testing
- `python3 -m py_compile AMmain.py`
- `python3 AMmain.py` *(fails: No module named 'PySide2')*

------
https://chatgpt.com/codex/tasks/task_e_68485db0435c832eb21c044a404f7ab1