### PR TITLE
Add camera export helper

### DIFF
--- a/AMUtilities.py
+++ b/AMUtilities.py
@@ -13,6 +13,11 @@ import json
 from pathlib import Path
 from typing import List, Dict, Any
 
+import math
+import numpy as np
+
+from CameraCalibrator import CameraCalibrator
+
 from PySide2 import QtGui
 
 
@@ -52,3 +57,68 @@ def load_scene(path: str) -> Dict[str, Any]:
 def verify_paths(paths: List[str]) -> List[str]:
     """Return only existing file paths."""
     return [p for p in paths if Path(p).exists()]
+
+
+def export_calibration_to_max(
+    calibrator: CameraCalibrator,
+    image_paths: List[str],
+    locator_names: List[str],
+    sensor_width_mm: float = 36.0,
+) -> None:
+    """Create cameras and dummies in the active 3ds Max scene.
+
+    Parameters
+    ----------
+    calibrator : CameraCalibrator
+        Calibrator containing recovered cameras and 3D points.
+    image_paths : List[str]
+        List of image paths corresponding to cameras. Used for naming.
+    locator_names : List[str]
+        Names of locators that correspond to the ``matches`` passed to
+        :meth:`CameraCalibrator.calibrate`.
+    sensor_width_mm : float, optional
+        Sensor width in millimeters, by default ``36.0``.
+    """
+
+    import pymxs
+
+    rt = pymxs.runtime
+
+    axes = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, -1.0, 0.0]])
+
+    cams = calibrator.get_camera_parameters()
+    K = calibrator.get_camera_intrinsics()
+    shapes = calibrator.get_image_shapes()
+
+    for idx, cam in enumerate(cams):
+        if cam.center is None or cam.rotation is None:
+            continue
+        name = Path(image_paths[idx]).stem if idx < len(image_paths) else f"cam{idx}"
+
+        pos = axes @ cam.center.reshape(3)
+        rot = axes @ cam.rotation.T
+
+        tm = rt.Matrix3(
+            rt.Point3(*rot[:, 0]),
+            rt.Point3(*rot[:, 1]),
+            rt.Point3(*rot[:, 2]),
+            rt.Point3(*pos),
+        )
+        node = rt.FreeCamera()
+        node.name = name
+        node.transform = tm
+
+        if K is not None and idx < len(shapes):
+            width_px = shapes[idx][1]
+            fx = float(K[0, 0])
+            focal_mm = fx / width_px * sensor_width_mm
+            try:
+                node.fov = 2 * math.atan(sensor_width_mm / (2 * focal_mm))
+            except AttributeError:
+                pass
+
+    for name, pt in calibrator.get_named_points_3d(locator_names):
+        pos = axes @ pt.reshape(3)
+        dummy = rt.Dummy()
+        dummy.name = name
+        dummy.position = rt.Point3(*pos)

--- a/CameraCalibrator.py
+++ b/CameraCalibrator.py
@@ -27,6 +27,7 @@ class CameraCalibrator:
         self._cameras: List[CameraParameters] = []
         self._points_3d: List[Optional[np.ndarray]] = []
         self._reprojection_error: Optional[float] = None
+        self._image_shapes: List[Tuple[int, int]] = []
 
     @staticmethod
     def _default_camera_matrix(image_shape: Tuple[int, int]) -> np.ndarray:
@@ -51,6 +52,7 @@ class CameraCalibrator:
         """
 
         num_cams = len(image_shapes)
+        self._image_shapes = list(image_shapes)
         if self._camera_matrix is None:
             self._camera_matrix = self._default_camera_matrix(image_shapes[0])
 
@@ -164,3 +166,19 @@ class CameraCalibrator:
 
     def get_reprojection_error(self) -> Optional[float]:
         return self._reprojection_error
+
+    def get_camera_intrinsics(self) -> Optional[np.ndarray]:
+        """Return the camera intrinsic matrix used for calibration."""
+        return self._camera_matrix
+
+    def get_image_shapes(self) -> List[Tuple[int, int]]:
+        """Return image sizes as ``(height, width)`` used in calibration."""
+        return list(self._image_shapes)
+
+    def get_named_points_3d(self, locator_names: List[str]) -> List[Tuple[str, np.ndarray]]:
+        """Return list of (name, point) for each successfully reconstructed locator."""
+        result: List[Tuple[str, np.ndarray]] = []
+        for name, pt in zip(locator_names, self._points_3d):
+            if pt is not None:
+                result.append((name, pt))
+        return result


### PR DESCRIPTION
## Summary
- extend CameraCalibrator with intrinsics access, image size storage and named 3d points
- implement export_calibration_to_max() in AMUtilities to create cameras and dummies in 3ds Max

## Testing
- `python -m py_compile CameraCalibrator.py AMUtilities.py`

------
https://chatgpt.com/codex/tasks/task_e_68488d7eea64832e9aa2bb6a9b006e2b