### PR TITLE
Add error-based locator visualization

### DIFF
--- a/AMUtilities.py
+++ b/AMUtilities.py
@@ -24,6 +24,13 @@ except ImportError:
 
 FORMAT_VERSION = 1
 
+def error_to_color(error: float, min_err: float = 0.0, max_err: float = 10.0) -> QtGui.QColor:
+    """Convert a numeric error value to a QColor along a green-red gradient."""
+    t = np.clip((error - min_err) / (max_err - min_err), 0.0, 1.0)
+    r = int(255 * t)
+    g = int(255 * (1.0 - t))
+    return QtGui.QColor(r, g, 0)
+
 def load_images(paths: List[str]) -> List[QtGui.QImage]:
     """Load images from disk.
 

--- a/CameraCalibrator.py
+++ b/CameraCalibrator.py
@@ -321,5 +321,61 @@ class CameraCalibrator:
             return []
         return [np.array(pt) for pt in self.calibration_results["points_3d"]]
 
-    def get_reprojection_error(self) -> Optional[float]:
-        return None
+    def get_reprojection_error(self) -> Optional[Dict[str, float]]:
+        """Return reprojection error for each locator (set_id)."""
+        if not self.calibration_results or not self.point_data:
+            return None
+
+        errors: Dict[str, float] = {}
+
+        # Build projection matrices for registered images
+        proj_mats: Dict[int, np.ndarray] = {}
+        for img_idx in self.calibration_results["registered_indices"]:
+            intr = self.calibration_results["intrinsics"].get(img_idx)
+            pose = self.calibration_results["poses"].get(img_idx)
+            if not intr or not pose:
+                continue
+            K = np.array(intr["K"], dtype=np.float64)
+            R_c2w = np.array(pose["R"], dtype=np.float64)
+            t_c2w = np.array(pose["t"], dtype=np.float64).reshape(3, 1)
+            R_w2c = R_c2w.T
+            t_w2c = -R_w2c @ t_c2w
+            P = K @ np.hstack((R_w2c, t_w2c))
+            proj_mats[img_idx] = P
+
+        def triangulate(obs):
+            A = []
+            for img_idx, (x, y) in obs.items():
+                if img_idx not in proj_mats:
+                    continue
+                P = proj_mats[img_idx]
+                A.append(x * P[2] - P[0])
+                A.append(y * P[2] - P[1])
+            if len(A) < 4:
+                return None
+            A = np.stack(A, axis=0)
+            _, _, vt = np.linalg.svd(A)
+            X = vt[-1]
+            X /= X[3]
+            return X[:3]
+
+        for set_id, obs in self.point_data.items():
+            pt3d = triangulate(obs)
+            if pt3d is None:
+                errors[str(set_id)] = float("inf")
+                continue
+            total_err = 0.0
+            count = 0
+            pt_h = np.hstack((pt3d, 1.0))
+            for img_idx, (x, y) in obs.items():
+                P = proj_mats.get(img_idx)
+                if P is None:
+                    continue
+                proj = P @ pt_h
+                proj /= proj[2]
+                err = np.linalg.norm(np.array([x, y]) - proj[:2])
+                total_err += err
+                count += 1
+            errors[str(set_id)] = total_err / count if count else float("inf")
+
+        return errors


### PR DESCRIPTION
## Summary
- compute per-locator reprojection error
- map error to color with new helper
- show crosshair markers colored by error
- color icons in locator tree
- refresh scene after calibration

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685f335fc834832ebf33b1938cd4c66f