### PR TITLE
Add error-based locator visualization

### DIFF
--- a/AMUtilities.py
+++ b/AMUtilities.py
@@ -24,6 +24,13 @@ except ImportError:
 
 FORMAT_VERSION = 1
 
+def error_to_color(error: float, min_err: float = 0.0, max_err: float = 10.0) -> QtGui.QColor:
+    """Convert a numeric error value to a QColor along a green-red gradient."""
+    t = np.clip((error - min_err) / (max_err - min_err), 0.0, 1.0)
+    r = int(255 * t)
+    g = int(255 * (1.0 - t))
+    return QtGui.QColor(r, g, 0)
+
 def load_images(paths: List[str]) -> List[QtGui.QImage]:
     """Load images from disk.
 

--- a/AMmain.py
+++ b/AMmain.py
@@ -90,24 +90,32 @@ class ImageViewer(QtWidgets.QGraphicsView):
         self.mark_items = []
         for m in markers:
             self._add_marker_item(
-                m["x"], m["y"], m.get("name", ""), m.get("name") == highlight_name
+                m["x"],
+                m["y"],
+                m.get("name", ""),
+                m.get("name") == highlight_name,
+                m.get("error")
             )
 
-    def _add_marker_item(self, x_norm: float, y_norm: float, name: str, highlight: bool = False):
-        rect = QtCore.QRectF(-5, -5, 10, 10)
-        item = QtWidgets.QGraphicsEllipseItem(rect)
-        color = QtCore.Qt.green if highlight else QtCore.Qt.red
-        item.setBrush(QtGui.QBrush(color))
-        item.setPen(QtGui.QPen(QtCore.Qt.black))
+    def _add_marker_item(self, x_norm: float, y_norm: float, name: str, highlight: bool = False, error: float = 0.0):
+        color = AMUtilities.error_to_color(error or 0.0)
+        pen = QtGui.QPen(color)
+        pen.setWidth(2 if highlight else 1)
         pos = QtCore.QPointF(x_norm * self.sceneRect().width(), y_norm * self.sceneRect().height())
-        item.setPos(pos)
-        item.setFlag(QtWidgets.QGraphicsItem.ItemIgnoresTransformations)
-        self.scene().addItem(item)
+
+        line1 = QtWidgets.QGraphicsLineItem(-5, 0, 5, 0)
+        line2 = QtWidgets.QGraphicsLineItem(0, -5, 0, 5)
+        for line in (line1, line2):
+            line.setPen(pen)
+            line.setPos(pos)
+            line.setFlag(QtWidgets.QGraphicsItem.ItemIgnoresTransformations)
+            self.scene().addItem(line)
+            self.mark_items.append(line)
+
         text = QtWidgets.QGraphicsSimpleTextItem(name)
         text.setFlag(QtWidgets.QGraphicsItem.ItemIgnoresTransformations)
         text.setPos(pos + QtCore.QPointF(6, -6))
         self.scene().addItem(text)
-        self.mark_items.append(item)
         self.mark_items.append(text)
 
     def mousePressEvent(self, event):
@@ -186,7 +194,12 @@ def get_image_markers(index: int):
     for loc in getattr(main_window, "locators", []):
         pos = loc.get("positions", {}).get(index)
         if pos:
-            markers.append({"name": loc["name"], "x": pos["x"], "y": pos["y"]})
+            markers.append({
+                "name": loc["name"],
+                "x": pos["x"],
+                "y": pos["y"],
+                "error": loc.get("error")
+            })
     return markers
 
 
@@ -197,15 +210,26 @@ def update_tree():
 
     img_root = QtWidgets.QTreeWidgetItem(tree, ["Images"])
     img_root.setData(0, QtCore.Qt.UserRole, ("images_root",))
+    img_errors = getattr(main_window, "image_errors", {})
     for idx, path in enumerate(main_window.image_paths):
         item = QtWidgets.QTreeWidgetItem(img_root, [Path(path).name])
         item.setData(0, QtCore.Qt.UserRole, ("image", idx))
+        err = img_errors.get(idx)
+        if err is not None:
+            color = AMUtilities.error_to_color(err)
+            icon = QtGui.QPixmap(16, 16)
+            icon.fill(color)
+            item.setIcon(0, QtGui.QIcon(icon))
 
     loc_root = QtWidgets.QTreeWidgetItem(tree, ["Locators"])
     loc_root.setData(0, QtCore.Qt.UserRole, ("loc_root",))
     for loc in getattr(main_window, "locators", []):
         item = QtWidgets.QTreeWidgetItem(loc_root, [loc["name"]])
         item.setData(0, QtCore.Qt.UserRole, ("locator", loc["name"]))
+        color = AMUtilities.error_to_color(loc.get("error", 0.0))
+        icon = QtGui.QPixmap(16, 16)
+        icon.fill(color)
+        item.setIcon(0, QtGui.QIcon(icon))
 
     img_root.setExpanded(True)
     loc_root.setExpanded(True)
@@ -304,6 +328,7 @@ def new_scene():
     main_window.images = []
     main_window.locators = []
     main_window.selected_locator = None
+    main_window.image_errors = {}
     update_tree()
     main_window.viewer._pixmap.setPixmap(QtGui.QPixmap())
     main_window.viewer.set_markers([])
@@ -319,6 +344,7 @@ def import_images():
     main_window.images = AMUtilities.load_images(paths)
     main_window.locators = []
     main_window.selected_locator = None
+    main_window.image_errors = {}
     update_tree()
     if main_window.images:
         show_image(0)
@@ -354,6 +380,7 @@ def load_scene():
     main_window.images = AMUtilities.load_images(main_window.image_paths)
     main_window.locators = scene["locators"]
     main_window.selected_locator = None
+    main_window.image_errors = {}
     update_tree()
     if main_window.images:
         show_image(0)
@@ -433,15 +460,25 @@ def calibrate():
         return
 
     main_window.calibration = calibrator
-    error = calibrator.get_reprojection_error()
+    err_dict = calibrator.get_reprojection_error() or {}
+    for idx, loc in enumerate(getattr(main_window, "locators", [])):
+        loc["error"] = err_dict.get(str(idx), None)
+    main_window.image_errors = calibrator.get_reprojection_errors_per_image() or {}
+
     msg = (
         f"Recovered {len(calibrator.get_camera_parameters())} cameras.\n"
         f"3D points: {len(calibrator.get_points_3d())}"
     )
-    if error is not None:
-        msg += f"\nReprojection error: {error:.4f}"
+    if err_dict:
+        avg_err = sum(err_dict.values()) / len(err_dict)
+        msg += f"\nReprojection error: {avg_err:.4f}"
+    if main_window.image_errors:
+        avg_img_err = sum(main_window.image_errors.values()) / len(main_window.image_errors)
+        msg += f"\nImage error: {avg_img_err:.4f}"
 
     QtWidgets.QMessageBox.information(main_window, "Calibration Completed", msg)
+    update_tree()
+    show_image(getattr(main_window, "current_image_index", 0), keep_view=True)
 
 
 
@@ -506,6 +543,7 @@ try:
         main_window.locators = []
         main_window.selected_locator = None
         main_window.locator_mode = False
+        main_window.image_errors = {}
 
         # Viewer setup inside MainFrame
         layout = QtWidgets.QVBoxLayout(main_window.MainFrame)

--- a/CameraCalibrator.py
+++ b/CameraCalibrator.py
@@ -321,5 +321,123 @@ class CameraCalibrator:
             return []
         return [np.array(pt) for pt in self.calibration_results["points_3d"]]
 
-    def get_reprojection_error(self) -> Optional[float]:
-        return None
+    def get_reprojection_error(self) -> Optional[Dict[str, float]]:
+        """Return reprojection error for each locator (set_id)."""
+        if not self.calibration_results or not self.point_data:
+            return None
+
+        errors: Dict[str, float] = {}
+
+        # Build projection matrices for registered images
+        proj_mats: Dict[int, np.ndarray] = {}
+        for img_idx in self.calibration_results["registered_indices"]:
+            intr = self.calibration_results["intrinsics"].get(img_idx)
+            pose = self.calibration_results["poses"].get(img_idx)
+            if not intr or not pose:
+                continue
+            K = np.array(intr["K"], dtype=np.float64)
+            R_c2w = np.array(pose["R"], dtype=np.float64)
+            t_c2w = np.array(pose["t"], dtype=np.float64).reshape(3, 1)
+            R_w2c = R_c2w.T
+            t_w2c = -R_w2c @ t_c2w
+            P = K @ np.hstack((R_w2c, t_w2c))
+            proj_mats[img_idx] = P
+
+        def triangulate(obs):
+            A = []
+            for img_idx, (x, y) in obs.items():
+                if img_idx not in proj_mats:
+                    continue
+                P = proj_mats[img_idx]
+                A.append(x * P[2] - P[0])
+                A.append(y * P[2] - P[1])
+            if len(A) < 4:
+                return None
+            A = np.stack(A, axis=0)
+            _, _, vt = np.linalg.svd(A)
+            X = vt[-1]
+            X /= X[3]
+            return X[:3]
+
+        for set_id, obs in self.point_data.items():
+            pt3d = triangulate(obs)
+            if pt3d is None:
+                errors[str(set_id)] = float("inf")
+                continue
+            total_err = 0.0
+            count = 0
+            pt_h = np.hstack((pt3d, 1.0))
+            for img_idx, (x, y) in obs.items():
+                P = proj_mats.get(img_idx)
+                if P is None:
+                    continue
+                proj = P @ pt_h
+                proj /= proj[2]
+                err = np.linalg.norm(np.array([x, y]) - proj[:2])
+                total_err += err
+                count += 1
+            errors[str(set_id)] = total_err / count if count else float("inf")
+
+        return errors
+
+    def get_reprojection_errors_per_image(self) -> Optional[Dict[int, float]]:
+        """Return reprojection error for each registered image."""
+        if not self.calibration_results or not self.point_data:
+            return None
+
+        proj_mats: Dict[int, np.ndarray] = {}
+        for img_idx in self.calibration_results["registered_indices"]:
+            intr = self.calibration_results["intrinsics"].get(img_idx)
+            pose = self.calibration_results["poses"].get(img_idx)
+            if not intr or not pose:
+                continue
+            K = np.array(intr["K"], dtype=np.float64)
+            R_c2w = np.array(pose["R"], dtype=np.float64)
+            t_c2w = np.array(pose["t"], dtype=np.float64).reshape(3, 1)
+            R_w2c = R_c2w.T
+            t_w2c = -R_w2c @ t_c2w
+            P = K @ np.hstack((R_w2c, t_w2c))
+            proj_mats[img_idx] = P
+
+        def triangulate(obs: Dict[int, Tuple[float, float]]):
+            A = []
+            for img_idx, (x, y) in obs.items():
+                if img_idx not in proj_mats:
+                    continue
+                P = proj_mats[img_idx]
+                A.append(x * P[2] - P[0])
+                A.append(y * P[2] - P[1])
+            if len(A) < 4:
+                return None
+            A = np.stack(A, axis=0)
+            _, _, vt = np.linalg.svd(A)
+            X = vt[-1]
+            X /= X[3]
+            return X[:3]
+
+        totals: Dict[int, float] = {idx: 0.0 for idx in proj_mats}
+        counts: Dict[int, int] = {idx: 0 for idx in proj_mats}
+
+        for obs in self.point_data.values():
+            pt3d = triangulate(obs)
+            if pt3d is None:
+                continue
+            pt_h = np.hstack((pt3d, 1.0))
+            for img_idx, (x, y) in obs.items():
+                P = proj_mats.get(img_idx)
+                if P is None:
+                    continue
+                proj = P @ pt_h
+                proj /= proj[2]
+                err = np.linalg.norm(np.array([x, y]) - proj[:2])
+                totals[img_idx] += err
+                counts[img_idx] += 1
+
+        errors: Dict[int, float] = {}
+        for idx in proj_mats:
+            if counts[idx]:
+                errors[idx] = totals[idx] / counts[idx]
+            else:
+                errors[idx] = float("inf")
+
+        return errors


### PR DESCRIPTION
## Summary
- compute per-locator reprojection error
- compute per-image reprojection error and colorize image nodes
- show crosshair markers colored by error
- color icons in locator tree
- refresh scene after calibration

## Testing
- `python -m py_compile AMmain.py CameraCalibrator.py AMUtilities.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685f335fc834832ebf33b1938cd4c66f