### PR TITLE
Fix worldspace transform on export

### DIFF
--- a/AMUtilities.py
+++ b/AMUtilities.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import numpy as np
 
@@ -129,6 +129,9 @@ def export_calibration_to_max(
     calibrator: CameraCalibrator,
     image_paths: List[str],
     locator_names: List[str],
+    world_R: Optional[np.ndarray] = None,
+    world_origin: Optional[np.ndarray] = None,
+    world_scale: float = 1.0,
 ) -> None:
     import pymxs
     import math
@@ -152,6 +155,11 @@ def export_calibration_to_max(
     def as_point3(vec: np.ndarray):
         return rt.Point3(float(vec[0]), float(vec[1]), float(vec[2]))
 
+    if world_R is None:
+        world_R = np.eye(3, dtype=np.float32)
+    if world_origin is None:
+        world_origin = np.zeros(3, dtype=np.float32)
+
     if not calibrator.calibration_results:
         raise RuntimeError("No calibration results found.")
 
@@ -167,7 +175,8 @@ def export_calibration_to_max(
 
     for pt, name in zip(points_3d, locator_names):
         pt_cv = np.array(pt, dtype=np.float32).reshape(3)
-        pt_max = OPENCV_TO_MAX @ pt_cv
+        pt_ws = world_scale * (world_R.T @ (pt_cv - world_origin))
+        pt_max = OPENCV_TO_MAX @ pt_ws
         dummy = rt.Dummy(name=name)
         dummy.position = as_point3(pt_max)
 
@@ -180,8 +189,11 @@ def export_calibration_to_max(
         R = np.array(pose["R"], dtype=np.float32)
         t = np.array(pose["t"], dtype=np.float32).reshape(3)
 
-        R_max = OPENCV_TO_MAX @ R @ CAMERA_ROT
-        t_max = OPENCV_TO_MAX @ t
+        R_ws = world_R.T @ R
+        t_ws = world_scale * (world_R.T @ (t - world_origin))
+
+        R_max = OPENCV_TO_MAX @ R_ws @ CAMERA_ROT
+        t_max = OPENCV_TO_MAX @ t_ws
 
         # Сборка трансформа
         T = np.eye(4)


### PR DESCRIPTION
## Summary
- compute worldspace transform from axis/center/scale settings
- apply the transform only during 3ds Max export

## Testing
- `python -m py_compile AMmain.py AMUtilities.py CameraCalibrator.py AMCalibrationPlotter.py`
- `python AMmain.py` *(fails: No module named 'PySide2')*

------
https://chatgpt.com/codex/tasks/task_e_685f4535dde4832e91a404ad4235741a